### PR TITLE
[v1] - custom component types

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ yarn rctgen --param value
 
 | Option        | Value          | Description                                                                          |
 | ------------- |--------------- | -------------------------------------------------------------------------------------|
-| --c           | Component name | Component name only CamelCase supported                                              |
+| --n           | Component name | Component name only CamelCase supported                                              |
 | --noCss       |                | Generates Component without styles                                                   |
 | --fn          |                | Generates function component instead of class Component                              |
 | --dir         | directory path | Generates component inside directory path which is relative to source directory      |
@@ -55,7 +55,7 @@ You can add to your `package.json` file
 
 ### Example
 
-running `rctgen --c Button` generates:
+running `rctgen --n Button` generates:
 
 ##### Files structure:
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
   "scripts": {
     "prepublish": "babel src --out-dir ./dist"
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "react",
     "cli",

--- a/rctgen.config.js
+++ b/rctgen.config.js
@@ -1,0 +1,41 @@
+const customClass = ({name, withCss = true, styleExt = 'scss'}) => `import * as React from 'react'
+${withCss ? "import './"+ name + "." + styleExt + "'\n" : ''}
+export default class ${name} extends React.Component {
+  render () {
+    return (
+      <div>Here is your ${name}</div>
+    )
+  }
+}`
+
+const customClassContainer = ({name, withCss = true, styleExt = 'scss'}) => `import * as React from 'react'
+import {connect} from 'react-redux'
+
+${withCss ? "import './"+ name + "." + styleExt + "'\n" : ''}
+class ${name} extends React.Component {
+  render () {
+    return (
+      <div>Here is your ${name}</div>
+    )
+  }
+}
+
+export default connect(state => state)(${name})
+`
+
+module.exports =  {
+    types: [
+        {
+            type: "component",
+            suffix: "Component",
+            dir: "components",
+            classTemplate: customClass
+        },
+        {
+            type: "container",
+            suffix: "Page",
+            dir: "containers",
+            classTemplate: customClassContainer
+        }
+    ]
+}

--- a/rctgen.config.js
+++ b/rctgen.config.js
@@ -29,7 +29,14 @@ module.exports =  {
             type: "component",
             suffix: "Component",
             dir: "components",
-            classTemplate: customClass
+            jsExt: 'tsx',
+            classTemplate: customClass,
+            additionalFiles: [
+                {
+                    file: 'types.ts',
+                    template: `export interface IProps {}\nexport interface IState {}`
+                }
+            ]
         },
         {
             type: "container",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-const _ = require('lodash');
-
 const fs = require('fs');
 const argv = require('minimist')(process.argv.slice(2));
 const findup = require('findup-sync');


### PR DESCRIPTION
I want to make it possible for users to create custom template and then generate it with selecting declared templates with `--t <template>`

So user can declare their own template like `container`, and then generate it in this way:

`rctgen --n Home --t container`

TODO
- [ ] update doc
- [ ] finish todos
- [ ] improve custom config (?)
- [ ] possibility of adding custom files like `types.ts` for Typescript users